### PR TITLE
Add website-publish CI workflow

### DIFF
--- a/.github/workflows/website-publish.yaml
+++ b/.github/workflows/website-publish.yaml
@@ -15,7 +15,10 @@ concurrency:
 jobs:
   build-and-publish:
     name: Build website and publish
-    runs-on: ubuntu-26.04
+    # ubuntu-24.04 (not 26.04) because ruby/setup-ruby does not support
+    # ubuntu-26.04 yet (no prebuilt Ruby binaries for it). Node is installed by
+    # setup-node regardless of the runner OS.
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/website-publish.yaml
+++ b/.github/workflows/website-publish.yaml
@@ -1,0 +1,75 @@
+name: website-publish
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Cancel a currently running workflow from the same PR, branch or tag when a
+  # new workflow is triggered.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish:
+    name: Build website and publish
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Honors .ruby-version (3.4.6) and installs gems into vendor/bundle
+          # (per .bundle/config), caching them between runs.
+          ruby-version: 3.4.6
+          bundler-cache: true
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install gulp CLI
+        run: npm install --global gulp-cli
+
+      # Builds the static website into _site/. GITHUB_TOKEN authenticates the
+      # GitHub API calls made by gulpfile.mjs.
+      - name: Build website
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: gulp build
+
+      # Publish only happens on push to master (and manual dispatch), never on
+      # pull requests.
+      - name: Publish website via rsync
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "$HOME/.ssh"
+          chmod 700 "$HOME/.ssh"
+          install -m 600 /dev/null "$HOME/.ssh/deploy_key"
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > "$HOME/.ssh/deploy_key"
+          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" >> "$HOME/.ssh/known_hosts"
+
+          # The destination path is "." (the root of the rrsync jail). The real
+          # target path is enforced server-side via the forced
+          # `command="rrsync -wo ..."` in authorized_keys.
+          rsync -rlvz --no-perms --delete-after \
+            -e "ssh -i $HOME/.ssh/deploy_key \
+                    -p ${{ secrets.SSH_PORT }} \
+                    -o IdentitiesOnly=yes \
+                    -o StrictHostKeyChecking=yes \
+                    -o UserKnownHostsFile=$HOME/.ssh/known_hosts" \
+            ./_site/ \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:."

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -16,8 +16,12 @@ import rsync from 'rsyncwrapper';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
 const pkg = JSON.parse(fs.readFileSync('./package.json').toString());
-const octokit = new Octokit();
+// Authenticated when GITHUB_TOKEN is set (CI), otherwise unauthenticated
+// (local dev). Authentication raises the GitHub API rate limit from 60 to
+// 1000 req/hour, which the 'replace' task needs to avoid being throttled.
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
 /**
  * Filter releases/tags with just X.Y.Z content.


### PR DESCRIPTION
# Details

- It builds the static website in a CI workflow and publishes it to our web server.

## Notes

- A new SSH key has been created to give the CI workflow access to the web server:
  ```bash
  ssh-keygen -t ed25519 -f deploy_key -C "gha-mediasoup-website" -N ""
  ```
- The new SSH public key has been added to `.ssh/authorized_keys` in the web server (under the home of the user used for deployments), which a content like this:
  ```bash
  # For mediasoup-website project to publish the website via GitHub CI. It uses rrsync command to narrow
  # access.
  command="rrsync -wo PATH_TO_THE_WEBSITE",restrict SSH_PUBLIC_KEY
  ```
- This protects access to the web server when using this key, so only usage is the `rsync` command and just in the given path.
- Many GitHub **secrets** have been added to the `mediasoup-website` project (see https://github.com/versatica/mediasoup-website/settings/secrets/actions). Those secrets are used by the workflow script as usual.
- The `SSH_KNOWN_HOSTS` is obtained via `ssh-keyscan -p SSH_PORT HOST`.

## TODO

- If this works fine, we may remove the `deploy` task in `gulpfile.mjs`, which right now basically exposes private info publicly...